### PR TITLE
fix: use token fallback instead of .stackblitzrc

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "PREPR_GRAPHQL_URL": "https://graphql.prepr.io/ac_5e48636ec968b4fe9b7490b0fc4f7702e51873418ae2acbc58c6431d9fe27429",
-    "PREPR_ENV": "preview"
-  }
-}

--- a/src/apollo-client.ts
+++ b/src/apollo-client.ts
@@ -6,7 +6,7 @@ export const {getClient, query, PreloadQuery} = registerApolloClient(() => {
     cache: new InMemoryCache(),
     link: new HttpLink({
       // this needs to be an absolute url, as relative urls cannot be used in SSR
-      uri: process.env.PREPR_GRAPHQL_URL,
+      uri: process.env.PREPR_GRAPHQL_URL || 'https://graphql.prepr.io/ac_5e48636ec968b4fe9b7490b0fc4f7702e51873418ae2acbc58c6431d9fe27429',
       // you can disable result caching here if you want to
       // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
       // fetchOptions: { cache: "no-store" },

--- a/src/app/[[...slug]]/layout.tsx
+++ b/src/app/[[...slug]]/layout.tsx
@@ -14,7 +14,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
     // Wrap in try-catch to handle cases where headers() can't be called during static generation
     if (isPreview) {
       try {
-        toolbarProps = await getToolbarProps(process.env.PREPR_GRAPHQL_URL!)
+        toolbarProps = await getToolbarProps((process.env.PREPR_GRAPHQL_URL || 'https://graphql.prepr.io/ac_5e48636ec968b4fe9b7490b0fc4f7702e51873418ae2acbc58c6431d9fe27429')!)
       } catch (error) {
         // During static generation (e.g., for not-found pages), headers() may not be available
         // Silently fail and render without the toolbar
@@ -23,7 +23,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
       }
     }
     
-    const accessToken = extractAccessToken(process.env.PREPR_GRAPHQL_URL!)
+    const accessToken = extractAccessToken((process.env.PREPR_GRAPHQL_URL || 'https://graphql.prepr.io/ac_5e48636ec968b4fe9b7490b0fc4f7702e51873418ae2acbc58c6431d9fe27429')!)
     
     return (
         <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({children,}: {children: React.ReactNode})
 {
-    const accessToken = extractAccessToken(process.env.PREPR_GRAPHQL_URL!)
+    const accessToken = extractAccessToken((process.env.PREPR_GRAPHQL_URL || 'https://graphql.prepr.io/ac_5e48636ec968b4fe9b7490b0fc4f7702e51873418ae2acbc58c6431d9fe27429')!)
     
   return (
       <html lang="en">


### PR DESCRIPTION
## Summary
- Removes `.stackblitzrc` (env injection via this file doesn't work reliably in StackBlitz)
- Adds inline `|| 'https://graphql.prepr.io/...'` fallback in `apollo-client.ts` and both layouts so the demo token is used automatically when `PREPR_GRAPHQL_URL` is not set

## Test plan
- [ ] Open in StackBlitz — app loads without needing to set env vars
- [ ] Local dev with `.env` still works as before (env var takes precedence over fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)