### PR TITLE
chore(security): fix CVEs (2026-08-20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,14 @@
       "js-yaml": ">=5.2.1",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
-      "postcss": ">=8.5.10",
+      "postcss": "^8.5.23",
       "shell-quote": "^1.9.0",
       "ws": ">=8.20.1",
       "brace-expansion": ">=5.0.7",
       "@babel/core": ">=7.29.6",
       "brace-expansion@>=3": "5.0.7",
-      "immutable": "^5.1.8"
+      "immutable": "^5.1.8",
+      "nanoid": "^3.3.18"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,14 @@ overrides:
   js-yaml: '>=5.2.1'
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
-  postcss: '>=8.5.10'
+  postcss: ^8.5.23
   shell-quote: ^1.9.0
   ws: '>=8.20.1'
   brace-expansion: '>=5.0.7'
   '@babel/core': '>=7.29.6'
   brace-expansion@>=3: 5.0.7
   immutable: ^5.1.8
+  nanoid: ^3.3.18
 
 importers:
 
@@ -33,7 +34,7 @@ importers:
         version: 3.2.0(graphql@16.13.2)
       '@preprio/prepr-nextjs':
         specifier: 2.2.6
-        version: 2.2.6(@types/react@19.2.14)(jiti@2.6.1)(next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.22)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.5.0(react@19.2.5))
+        version: 2.2.6(@types/react@19.2.14)(jiti@2.6.1)(next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.26)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.5.0(react@19.2.5))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1758,13 +1759,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1876,14 +1872,14 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: ^8.5.23
 
   postcss-load-config@5.1.0:
     resolution: {integrity: sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.10'
+      postcss: ^8.5.23
       tsx: ^4.8.1
     peerDependenciesMeta:
       jiti:
@@ -1897,14 +1893,10 @@ packages:
     resolution: {integrity: sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==}
     engines: {node: '>=10'}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: ^8.5.23
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-hrtime@1.0.3:
@@ -3198,14 +3190,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@preprio/prepr-nextjs@2.2.6(@types/react@19.2.14)(jiti@2.6.1)(next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.22)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.5.0(react@19.2.5))':
+  '@preprio/prepr-nextjs@2.2.6(@types/react@19.2.14)(jiti@2.6.1)(next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.26)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.5.0(react@19.2.5))':
     dependencies:
       '@headlessui/react': 2.2.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vercel/functions': 3.4.4
       '@vercel/stega': 1.1.0
       clsx: 2.1.1
       next: 16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      postcss-cli: 11.0.1(jiti@2.6.1)(postcss@8.5.22)
+      postcss-cli: 11.0.1(jiti@2.6.1)(postcss@8.5.26)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tailwind-merge: 3.5.0
@@ -3344,7 +3336,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
-      postcss: 8.5.14
+      postcss: 8.5.26
       tailwindcss: 4.2.4
 
   '@tanstack/react-virtual@3.13.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -3966,9 +3958,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -3976,7 +3966,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.1
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.22
+      postcss: 8.5.26
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@8.0.1)(react@19.2.5)
@@ -4078,15 +4068,15 @@ snapshots:
 
   pify@2.3.0: {}
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.22):
+  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.26):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.0
       picocolors: 1.1.1
-      postcss: 8.5.22
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.22)
-      postcss-reporter: 7.1.0(postcss@8.5.22)
+      postcss: 8.5.26
+      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.26)
+      postcss-reporter: 7.1.0(postcss@8.5.26)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -4096,29 +4086,23 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.22):
+  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.26):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.22
+      postcss: 8.5.26
 
-  postcss-reporter@7.1.0(postcss@8.5.22):
+  postcss-reporter@7.1.0(postcss@8.5.26):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.22
+      postcss: 8.5.26
       thenby: 1.3.4
 
-  postcss@8.5.14:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.22:
-    dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Security & dependency fixes — 2026-08-20

Automatically applied by `/cve-fix`. Patch and minor bumps only.

### Security CVE fixes

| Severity | Package | From | To | CVE | GHSA | Summary |
|----------|---------|------|----|-----|------|---------|
| high | nanoid | 3.3.11 | 3.3.18 | CVE-2026-67213 | GHSA-2v37-7h3g-55p8 | nanoid: custom generators can loop indefinitely when size is zero |
| medium | postcss | 8.4.31 | 8.5.23 | CVE-2026-69153 | GHSA-fxqj-rqcc-2cmp | PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset |

> Major bumps requiring manual review are listed in the [CVE manual review report](/Users/kevinquaedvlieg/Code/prepr/cve-manual-review-2026-08-20.md).
