### PR TITLE
chore(security): fix CVEs (2026-08-21-r3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "overrides": {
       "@types/react": "19.2.14",
       "@types/react-dom": "19.2.3",
-      "js-yaml": ">=5.2.1",
+      "js-yaml": "5.2.2",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
       "postcss": "^8.5.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
-  js-yaml: '>=5.2.1'
+  js-yaml: 5.2.2
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
   postcss: ^8.5.23
@@ -1590,8 +1590,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3566,7 +3566,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -3576,7 +3576,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -3819,7 +3819,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Security fixes — 2026-08-21-r3

Automatically applied by `/cve-fix` (security patch/minor only).

| Severity | Package | Installed | To | CVE | GHSA | Summary |
|----------|---------|-----------|----|-----|------|---------|
| high | js-yaml | 5.2.1 | 5.2.2 | CVE-2026-73643 | GHSA-pm4m-ph32-ghv5 | js-yaml: Exponential parsing time in flow collections leads to denial of service |
